### PR TITLE
Added support for an optional `session-name` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ See the [Habitr](https://github.com/dnys1/habitr/blob/main/.github/workflows/dep
 
 The action supports the following inputs:
 
-| Input Name | Required | Default | Description |
-| ---------- | -------- | ------- | ----------- |
-| app-id | x | | The Amplify App ID of your project. |
-| role-arn | x | | The Role ARN from `Getting Started`. |
-| region | x | | The AWS region where your project is hosted. |
-| env-name | | `dev` | The Amplify environment to pull. |
-| version | | latest | The Amplify CLI version to use. |
+| Input Name   | Required | Default                  | Description                                                                                                 |
+|--------------| -------- |--------------------------|-------------------------------------------------------------------------------------------------------------|
+| app-id       | x |                          | The Amplify App ID of your project.                                                                         |
+| role-arn     | x |                          | The Role ARN from `Getting Started`.                                                                        |
+| region       | x |                          | The AWS region where your project is hosted.                                                                |
+| session-name | | $actor-$workflow-$action | Defaults to a concatenation of the GitHub properties, but you can override with your own values if desired. |
+| env-name     | | `dev`                    | The Amplify environment to pull.                                                                            |
+| version      | | latest                   | The Amplify CLI version to use.                                                                             |

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,10 @@ inputs:
     description: 'The Amplify environment to pull.'
     required: true
     default: dev
+  session-name:
+    description: 'The AWS roleSessionName associated with the GitHub action.'
+    required: false
+    default: ${{ github.actor }}-${{ github.workflow }}-${{ github.action }}
   version:
     description: 'The Amplify CLI version to use (e.g. "7.6.10"). Defaults to "latest".'
     required: false
@@ -35,7 +39,7 @@ runs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: ${{ inputs.role-arn }}
-        role-session-name: ${{ github.actor }}-${{ github.workflow }}-${{ github.action }}
+        role-session-name: ${{ inputs.session-name }}
         aws-region: ${{ inputs.region }}
     - name: Pull Amplify project
       shell: bash


### PR DESCRIPTION
I can see in the code where the session name that is passed to the `configure-aws-credentials` action is hardcoded using the following pattern.

```yaml
role-session-name: ${{ github.actor }}-${{ github.workflow }}-${{ github.action }}
```

In my case, this is causing the resulting `roleSessionName` to violate a couple of constraints. 

```
Error: 2 validation errors detected: Value 'oravecz-CitySleuth App Action-__dnys1_amplify-flutter-pull-action' at 'roleSessionName' failed to satisfy constraint: Member must have length less than or equal to 64; Value 'oravecz-CitySleuth App Action-__dnys1_amplify-flutter-pull-action' at 'roleSessionName' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w+=,.@-]*
```

I'll remove the spaces in my action workflow name which should satisfy both constraints in this case, but this PR is intended to add an optional parameter to the custom action to support the new `session-name` parameter.

> Note: I didn't push this to the GitHub Marketplace for testing as I didn't want to cause confusion between a forked package and this package. I am not sure if the GitHub Actions format allows an input to be concatenated from GitHub properties. If that is not allowed, this PR will not work the way it is written.
 
